### PR TITLE
Add requirements.txt to MANFEST.in

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -27,3 +27,4 @@ Patches and Suggestions
 - James Page
 - Josh Marshall
 - Dougal Matthews
+- Monty Taylor

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 
 History
 -------
+1.3.1 (2014-09-30)
+++++++++++++++++++
+- Add requirements.txt to MANIFEST.in to fix pip installs
+
 1.3.0 (2014-09-30)
 ++++++++++++++++++
 - Add upstream six dependency, remove embedded six functionality

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.rst HISTORY.rst AUTHORS.rst LICENSE NOTICE
+include README.rst HISTORY.rst AUTHORS.rst LICENSE NOTICE requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ with open('requirements.txt') as file_requirements:
 
 settings.update(
     name='retrying',
-    version='1.3.0',
+    version='1.3.1',
     description='Retrying',
     long_description=readme + '\n\n' + history,
     author='Ray Holder',


### PR DESCRIPTION
Without this, pip installs of retrying all fail due to requirements.txt
being missing in the tarball but required by setup.py.
