### PR TITLE
Extend API to allow specifying the exception class

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 
 History
 -------
+
+1.4.X (unreleased)
+++++++++++++++++++
+- Add on_exception parameter to catch only specific exceptions.
+- By default only catch subclasses of Exception rather than BaseException.
+
 1.3.1 (2014-09-30)
 ++++++++++++++++++
 - Add requirements.txt to MANIFEST.in to fix pip installs

--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,20 @@ Then again, it's hard to beat exponential backoff when retrying distributed serv
         print "Wait 2^x * 1000 milliseconds between each retry, up to 10 seconds, then 10 seconds afterwards"
 
 
-We have a few options for dealing with retries that raise specific or general exceptions, as in the cases here.
+We can retry the method on specific exceptions (and their subclasses)
+
+.. code-block:: python
+
+    @retry(on_exception=IOError)
+    def might_io_error():
+        print "Retry forever with no wait if an IOError occurs, raise any other errors"
+
+    @retry(on_exception=(IOError, ValueError))
+    def might_io_error_or_value_error():
+        print "Retry forever with no wait if an IOError or ValueError occurs, raise any other errors"
+
+
+Alternatively we have a few options for dealing with retries that raise specific or general exceptions, as in the cases here.
 
 .. code-block:: python
 
@@ -128,6 +141,7 @@ We have a few options for dealing with retries that raise specific or general ex
     @retry(retry_on_exception=retry_if_io_error, wrap_exception=True)
     def only_raise_retry_error_when_not_io_error():
         print "Retry forever with no wait if an IOError occurs, raise any other errors wrapped in RetryError"
+
 
 We can also use the result of the function to alter the behavior of retrying.
 

--- a/retrying.py
+++ b/retrying.py
@@ -86,7 +86,8 @@ class Retrying(object):
                  retry_on_result=None,
                  wrap_exception=False,
                  stop_func=None,
-                 wait_func=None):
+                 wait_func=None,
+                 on_exception=Exception):
 
         self._stop_max_attempt_number = 5 if stop_max_attempt_number is None else stop_max_attempt_number
         self._stop_max_delay = 100 if stop_max_delay is None else stop_max_delay
@@ -97,6 +98,7 @@ class Retrying(object):
         self._wait_incrementing_increment = 100 if wait_incrementing_increment is None else wait_incrementing_increment
         self._wait_exponential_multiplier = 1 if wait_exponential_multiplier is None else wait_exponential_multiplier
         self._wait_exponential_max = MAX_WAIT if wait_exponential_max is None else wait_exponential_max
+        self._on_exception = on_exception
 
         # TODO add chaining of stop behaviors
         # stop behavior
@@ -215,7 +217,7 @@ class Retrying(object):
         while True:
             try:
                 attempt = Attempt(fn(*args, **kwargs), attempt_number, False)
-            except:
+            except self._on_exception:
                 tb = sys.exc_info()
                 attempt = Attempt(tb, attempt_number, True)
 

--- a/test_retrying.py
+++ b/test_retrying.py
@@ -287,6 +287,18 @@ def _retryable_test_with_exception_type_custom_attempt_limit(thing):
 def _retryable_test_with_exception_type_custom_attempt_limit_wrap(thing):
     return thing.go()
 
+@retry(on_exception=IOError)
+def _retryable_test_on_ioerror(thing):
+    return thing.go()
+
+@retry(on_exception=NameError)
+def _retryable_test_on_name_error(thing):
+    return thing.go()
+
+@retry(on_exception=(IOError, NameError))
+def _retryable_test_on_ioerror_or_name_error(thing):
+    return thing.go()
+
 class TestDecoratorWrapper(unittest.TestCase):
 
     def test_with_wait(self):
@@ -408,6 +420,33 @@ class TestDecoratorWrapper(unittest.TestCase):
         self.assertTrue(_retryable_default_f(NoNameErrorAfterCount(5)))
         self.assertTrue(_retryable_default(NoCustomErrorAfterCount(5)))
         self.assertTrue(_retryable_default_f(NoCustomErrorAfterCount(5)))
+
+    def test_on_exception_success(self):
+        """
+        The _retryable_test_on_ioerror method is setup to retry only on IOError
+        exceptions. The NoIOErrorAfterCount will raise this, and it will be
+        retried.
+        """
+        self.assertTrue(_retryable_test_on_ioerror(NoIOErrorAfterCount(5)))
+
+    def test_on_exception_fail(self):
+        """
+        The _retryable_test_on_name_error method is setup to retry only on
+        NameError. The NoIOErrorAfterCount raises an IOError and thus the
+        exception is propagated.
+        """
+        self.assertRaises(
+            IOError,
+            _retryable_test_on_name_error, NoIOErrorAfterCount(1))
+
+    def test_on_exception_fail(self):
+        """
+        The _retryable_test_on_name_error method is setup to retry only on
+        NameError. The NoIOErrorAfterCount raises an IOError and thus the
+        exception is propagated.
+        """
+        self.assertTrue(_retryable_test_on_ioerror_or_name_error, NoIOErrorAfterCount(1))
+        self.assertTrue(_retryable_test_on_ioerror_or_name_error, NoNameErrorAfterCount(1))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Adds an `on_exception` argument to specify the class of exception to catch. This provides a cleaner API to catching only specific exception classes.

Opening this in part as a POC and to start discussion. I think it is a much nicer API for this use case and also solves the issue of catching `BaseException` by default.

See #17