### PR TITLE
adding test case for randomized exponential backoff

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -21,6 +21,7 @@ Patches and Suggestions
 - Josh Marshall
 - Joshua Harlow
 - Justin Turner Arthur
+- Kerey Roper
 - Monty Taylor
 - Pierre-Yves Chibon
 - Rees Dooley

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,21 +10,21 @@ Development Lead
 Patches and Suggestions
 ```````````````````````
 
-- Anthony McClosky
-- Jason Dunkelberger
-- Justin Turner Arthur
-- J Derek Wilson
 - Alex Kuang
-- Simon Dollé
+- Anthony McClosky
+- Daniel Nephin
+- Dougal Matthews
+- Haïkel Guémar
+- J Derek Wilson
+- James Page
+- Jason Dunkelberger
+- Josh Marshall
+- Joshua Harlow
+- Justin Turner Arthur
+- Monty Taylor
+- Pierre-Yves Chibon
 - Rees Dooley
 - Saul Shanabrook
-- Daniel Nephin
 - Simeon Visser
-- Joshua Harlow
-- Pierre-Yves Chibon
-- Haïkel Guémar
+- Simon Dollé
 - Thomas Goirand
-- James Page
-- Josh Marshall
-- Dougal Matthews
-- Monty Taylor


### PR DESCRIPTION
I noticed there were some plans for composing wait functions in a manner other than max, which sounds interesting. Hopefully this means randomized exponential backoff will be supported out of the box, but in the meantime, here's a helpful test case and a sample custom wait function that implements it. Basic exponential backoff doesn't really alleviate the spiky congestion or rate limited case since it doesn't provide any smoothing function.