### PR TITLE
Allow a jitter value to be passed in

### DIFF
--- a/retrying.py
+++ b/retrying.py
@@ -86,7 +86,8 @@ class Retrying(object):
                  retry_on_result=None,
                  wrap_exception=False,
                  stop_func=None,
-                 wait_func=None):
+                 wait_func=None,
+                 wait_jitter_max=None):
 
         self._stop_max_attempt_number = 5 if stop_max_attempt_number is None else stop_max_attempt_number
         self._stop_max_delay = 100 if stop_max_delay is None else stop_max_delay
@@ -97,6 +98,7 @@ class Retrying(object):
         self._wait_incrementing_increment = 100 if wait_incrementing_increment is None else wait_incrementing_increment
         self._wait_exponential_multiplier = 1 if wait_exponential_multiplier is None else wait_exponential_multiplier
         self._wait_exponential_max = MAX_WAIT if wait_exponential_max is None else wait_exponential_max
+        self._wait_jitter_max = 0 if wait_jitter_max is None else wait_jitter_max
 
         # TODO add chaining of stop behaviors
         # stop behavior
@@ -231,6 +233,9 @@ class Retrying(object):
                     raise RetryError(attempt)
             else:
                 sleep = self.wait(attempt_number, delay_since_first_attempt_ms)
+                if self._wait_jitter_max:
+                    jitter = random.random() * self._wait_jitter_max
+                    sleep = sleep + max(0, jitter)
                 time.sleep(sleep / 1000.0)
 
             attempt_number += 1


### PR DESCRIPTION
To avoid the thundering herd problem when retrying is
triggered at exactly the same moment by many entities
allow for passing in a jitter maximum value which will
be used to randomly alter the amount of time slept
by each retrying object user; this helps randomize the
thundering herd and makes it possible to reduce the
issue.
