### PR TITLE
fixed wrapped function information loss

### DIFF
--- a/retrying.py
+++ b/retrying.py
@@ -40,6 +40,7 @@ import six
 import sys
 import time
 import traceback
+from functools import wraps 
 
 
 # sys.maxint / 2, since Python 3.2 doesn't have a sys.maxint...
@@ -55,6 +56,7 @@ def retry(*dargs, **dkw):
     # support both @retry and @retry() as valid syntax
     if len(dargs) == 1 and callable(dargs[0]):
         def wrap_simple(f):
+            @wraps(f)
             def wrapped_f(*args, **kw):
                 return Retrying().call(f, *args, **kw)
 
@@ -64,6 +66,7 @@ def retry(*dargs, **dkw):
 
     else:
         def wrap(f):
+            @wraps(f)
             def wrapped_f(*args, **kw):
                 return Retrying(*dargs, **dkw).call(f, *args, **kw)
 


### PR DESCRIPTION
for more details about this problem take a look at http://stackoverflow.com/questions/306130/python-decorator-makes-function-forget-that-it-belongs-to-a-class#306277 or http://stackoverflow.com/questions/308999/what-does-functools-wraps-do
