### PR TITLE
ensure int args are ints

### DIFF
--- a/retrying.py
+++ b/retrying.py
@@ -70,16 +70,16 @@ class Retrying(object):
                  wait_func=None,
                  wait_jitter_max=None):
 
-        self._stop_max_attempt_number = 5 if stop_max_attempt_number is None else stop_max_attempt_number
-        self._stop_max_delay = 100 if stop_max_delay is None else stop_max_delay
-        self._wait_fixed = 1000 if wait_fixed is None else wait_fixed
-        self._wait_random_min = 0 if wait_random_min is None else wait_random_min
-        self._wait_random_max = 1000 if wait_random_max is None else wait_random_max
-        self._wait_incrementing_start = 0 if wait_incrementing_start is None else wait_incrementing_start
-        self._wait_incrementing_increment = 100 if wait_incrementing_increment is None else wait_incrementing_increment
-        self._wait_exponential_multiplier = 1 if wait_exponential_multiplier is None else wait_exponential_multiplier
-        self._wait_exponential_max = MAX_WAIT if wait_exponential_max is None else wait_exponential_max
-        self._wait_jitter_max = 0 if wait_jitter_max is None else wait_jitter_max
+        self._stop_max_attempt_number = 5 if stop_max_attempt_number is None else int(stop_max_attempt_number)
+        self._stop_max_delay = 100 if stop_max_delay is None else int(stop_max_delay)
+        self._wait_fixed = 1000 if wait_fixed is None else int(wait_fixed)
+        self._wait_random_min = 0 if wait_random_min is None else int(wait_random_min)
+        self._wait_random_max = 1000 if wait_random_max is None else int(wait_random_max)
+        self._wait_incrementing_start = 0 if wait_incrementing_start is None else int(wait_incrementing_start)
+        self._wait_incrementing_increment = 100 if wait_incrementing_increment is None else int(wait_incrementing_increment)
+        self._wait_exponential_multiplier = 1 if wait_exponential_multiplier is None else int(wait_exponential_multiplier)
+        self._wait_exponential_max = MAX_WAIT if wait_exponential_max is None else int(wait_exponential_max)
+        self._wait_jitter_max = 0 if wait_jitter_max is None else int(wait_jitter_max)
 
         # TODO add chaining of stop behaviors
         # stop behavior


### PR DESCRIPTION
I often use retrying where retry args are taken from some config file. It is easy to pass string instead of int by accident. In such case there are very unexpected errors as comparison of string with int is valid comparison. For example:

``` python
import retrying
def f():
   return 1

rargs = {
   'retry_on_result': lambda x: x == 1,
   'stop_max_delay': '1' # this is string by accident
}

retrying.Retrying(**rargs).call(f)
```

this will run indefinitely, without any warning.
This PR fixes this issue by enforcing int type of passed arguments
