### PR TITLE
Support for retry event hook

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -31,3 +31,4 @@ Patches and Suggestions
 - Maxym Shalenyi
 - Jonathan Herriott
 - Job Evers
+- Boden Russell

--- a/README.rst
+++ b/README.rst
@@ -144,6 +144,19 @@ We can also use the result of the function to alter the behavior of retrying.
 
 Any combination of stop, wait, etc. is also supported to give you the freedom to mix and match.
 
+It's also possible to provide a custom hook function that'll be called on each re-attempt
+of a retry prior to the next wait. The return value of this hook is not used.
+
+.. code-block:: python
+
+    def log_retry(next_wait_time, prev_attempt, time_since_first_attempt):
+        log.warning("Operation failed. Trying again in %s ms" % next_wait_time)
+
+    @retry(wait_event_func=log_retry)
+    def logged_on_each_retry():
+        my_operation()
+
+
 Contribute
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -144,18 +144,6 @@ We can also use the result of the function to alter the behavior of retrying.
 
 Any combination of stop, wait, etc. is also supported to give you the freedom to mix and match.
 
-It's also possible to provide a custom hook function that'll be called on each re-attempt
-of a retry prior to the next wait. The return value of this hook is not used.
-
-.. code-block:: python
-
-    def log_retry(next_wait_time, prev_attempt, time_since_first_attempt):
-        log.warning("Operation failed. Trying again in %s ms" % next_wait_time)
-
-    @retry(wait_event_func=log_retry)
-    def logged_on_each_retry():
-        my_operation()
-
 
 Contribute
 ----------

--- a/retrying.py
+++ b/retrying.py
@@ -68,7 +68,8 @@ class Retrying(object):
                  wrap_exception=False,
                  stop_func=None,
                  wait_func=None,
-                 wait_jitter_max=None):
+                 wait_jitter_max=None,
+                 wait_event_func=None):
 
         self._stop_max_attempt_number = 5 if stop_max_attempt_number is None else stop_max_attempt_number
         self._stop_max_delay = 100 if stop_max_delay is None else stop_max_delay
@@ -80,6 +81,7 @@ class Retrying(object):
         self._wait_exponential_multiplier = 1 if wait_exponential_multiplier is None else wait_exponential_multiplier
         self._wait_exponential_max = MAX_WAIT if wait_exponential_max is None else wait_exponential_max
         self._wait_jitter_max = 0 if wait_jitter_max is None else wait_jitter_max
+        self._wait_event_func = wait_event_func if wait_event_func is not None else lambda next_wait, attempts, delay: None
 
         # TODO add chaining of stop behaviors
         # stop behavior
@@ -214,6 +216,7 @@ class Retrying(object):
                     raise RetryError(attempt)
             else:
                 sleep = self.wait(attempt_number, delay_since_first_attempt_ms)
+                self._wait_event_func(sleep, attempt_number, delay_since_first_attempt_ms)
                 if self._wait_jitter_max:
                     jitter = random.random() * self._wait_jitter_max
                     sleep = sleep + max(0, jitter)

--- a/test_retrying.py
+++ b/test_retrying.py
@@ -470,43 +470,5 @@ class TestBeforeAfterAttempts(unittest.TestCase):
         self.assertTrue(TestBeforeAfterAttempts._attempt_number is 2)
 
 
-class TestRetryEvent(unittest.TestCase):
-
-    def setUp(self):
-        self._event_calls = []
-
-    def _mark_event_call(self, sleep_time, prev_attempt, since_first):
-        self._event_calls.append((sleep_time, prev_attempt, since_first))
-
-    def test_custom_wait_hook_init(self):
-        retrying = Retrying(wait_event_func=self._mark_event_call)
-        self.assertEqual(self._mark_event_call, retrying._wait_event_func)
-
-    def test_custom_wait_hook_call(self):
-
-        @retry(wait_event_func=self._mark_event_call, stop_max_attempt_number=4, wait_fixed=10)
-        def wait_with_events():
-            raise Exception()
-
-        self.assertRaises(Exception, wait_with_events)
-        self.assertEqual(3, len(self._event_calls))
-        for i in range(0, 3):
-            self.assertEqual(10, self._event_calls[i][0])
-            self.assertEqual(i + 1, self._event_calls[i][1])
-
-    def test_no_custom_wait_hook_call(self):
-
-        @retry(stop_max_attempt_number=4, wait_fixed=10)
-        def wait_with_events():
-            raise Exception()
-
-        self.assertRaises(Exception, wait_with_events)
-        self.assertEqual(0, len(self._event_calls))
-
-    def test_default_wait_hook_init(self):
-        retrying = Retrying()
-        self.assertTrue(retrying._wait_event_func is not None)
-        self.assertNotEqual(self._mark_event_call, retrying._wait_event_func)
-
 if __name__ == '__main__':
     unittest.main()

--- a/test_retrying.py
+++ b/test_retrying.py
@@ -434,5 +434,45 @@ class TestDecoratorWrapper(unittest.TestCase):
         self.assertTrue(_retryable_default(NoCustomErrorAfterCount(5)))
         self.assertTrue(_retryable_default_f(NoCustomErrorAfterCount(5)))
 
+
+class TestRetryEvent(unittest.TestCase):
+
+    def setUp(self):
+        self._event_calls = []
+
+    def _mark_event_call(self, sleep_time, prev_attempt, since_first):
+        self._event_calls.append((sleep_time, prev_attempt, since_first))
+
+    def test_custom_wait_hook_init(self):
+        retrying = Retrying(wait_event_func=self._mark_event_call)
+        self.assertEqual(self._mark_event_call, retrying._wait_event_func)
+
+    def test_custom_wait_hook_call(self):
+
+        @retry(wait_event_func=self._mark_event_call, stop_max_attempt_number=4, wait_fixed=10)
+        def wait_with_events():
+            raise Exception()
+
+        self.assertRaises(Exception, wait_with_events)
+        self.assertEqual(3, len(self._event_calls))
+        for i in range(0, 3):
+            self.assertEqual(10, self._event_calls[i][0])
+            self.assertEqual(i + 1, self._event_calls[i][1])
+
+    def test_no_custom_wait_hook_call(self):
+
+        @retry(stop_max_attempt_number=4, wait_fixed=10)
+        def wait_with_events():
+            raise Exception()
+
+        self.assertRaises(Exception, wait_with_events)
+        self.assertEqual(0, len(self._event_calls))
+
+    def test_default_wait_hook_init(self):
+        retrying = Retrying()
+        self.assertTrue(retrying._wait_event_func is not None)
+        self.assertNotEqual(self._mark_event_call, retrying._wait_event_func)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/test_retrying.py
+++ b/test_retrying.py
@@ -470,7 +470,7 @@ class TestRetryEvent(unittest.TestCase):
 
     def test_default_wait_hook_init(self):
         retrying = Retrying()
-        self.assertIsNotNone(retrying._wait_event_func)
+        self.assertTrue(retrying._wait_event_func)
         self.assertNotEqual(self._mark_event_call, retrying._wait_event_func)
 
 

--- a/test_retrying.py
+++ b/test_retrying.py
@@ -434,5 +434,45 @@ class TestDecoratorWrapper(unittest.TestCase):
         self.assertTrue(_retryable_default(NoCustomErrorAfterCount(5)))
         self.assertTrue(_retryable_default_f(NoCustomErrorAfterCount(5)))
 
+
+class TestRetryEvent(unittest.TestCase):
+
+    def setUp(self):
+        self._event_calls = []
+
+    def _mark_event_call(self, sleep_time, prev_attempt, since_first):
+        self._event_calls.append((sleep_time, prev_attempt, since_first))
+
+    def test_custom_wait_hook_init(self):
+        retrying = Retrying(wait_event_func=self._mark_event_call)
+        self.assertEqual(self._mark_event_call, retrying._wait_event_func)
+
+    def test_custom_wait_hook_call(self):
+
+        @retry(wait_event_func=self._mark_event_call, stop_max_attempt_number=4, wait_fixed=10)
+        def wait_with_events():
+            raise Exception()
+
+        self.assertRaises(Exception, wait_with_events)
+        self.assertEqual(3, len(self._event_calls))
+        for i in range(0, 3):
+            self.assertEqual(10, self._event_calls[i][0])
+            self.assertEqual(i + 1, self._event_calls[i][1])
+
+    def test_no_custom_wait_hook_call(self):
+
+        @retry(stop_max_attempt_number=4, wait_fixed=10)
+        def wait_with_events():
+            raise Exception()
+
+        self.assertRaises(Exception, wait_with_events)
+        self.assertEqual(0, len(self._event_calls))
+
+    def test_default_wait_hook_init(self):
+        retrying = Retrying()
+        self.assertIsNotNone(retrying._wait_event_func)
+        self.assertNotEqual(self._mark_event_call, retrying._wait_event_func)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
It's very common for consumers to perform some action on each
attempt iteration; for example logging a message that the operation
failed and a retry will be performed after some time. While this can
be done today using a custom wait_func, it's inconvenient to use
a partial to wrap an existing retrying sleep function just to get this
behavior.

This patch adds support for a new kwarg called wait_event_func
that when passed should reference a function to be called
before sleeping for another attempt iteration. This function
looks similar to retrying wait_funcs except its first arg is
the time to sleep as returned by the current 'wait' function.

A handful of unit tests are also included.
