### PR TITLE
Support for marked wait

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -31,3 +31,4 @@ Patches and Suggestions
 - Maxym Shalenyi
 - Jonathan Herriott
 - Job Evers
+- Boden Russell

--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,16 @@ Then again, it's hard to beat exponential backoff when retrying distributed serv
     def wait_exponential_1000():
         print "Wait 2^x * 1000 milliseconds between each retry, up to 10 seconds, then 10 seconds afterwards"
 
+One can also use attempt markers to set specific wait times that into effect on a said attempt number.
+Markers are a set of tuples where the 1st element is the attempt (must be greater than 1) and the 2nd element
+is the number of ms to wait. A said marker goes into effect on it's attempt and is active until
+another is hit.
+
+.. code-block:: python
+
+    @retry(wait_markers=[(1, 100), (5, 1000), (10, 4000)], stop_max_attempt_number=20)
+    def wait_with_markers():
+        print "Wait 100ms attempts 1-5, 1000ms 5-10 and 4000ms from attempts 10-20 stopping after 20 attempts"
 
 We have a few options for dealing with retries that raise specific or general exceptions, as in the cases here.
 

--- a/test_retrying.py
+++ b/test_retrying.py
@@ -132,6 +132,20 @@ class TestWaitConditions(unittest.TestCase):
         self.assertEqual(r.wait(2, 11), 22)
         self.assertEqual(r.wait(10, 100), 1000)
 
+    def test_marked_wait(self):
+        r = Retrying(wait_markers=[(1, 1), (2, 2), (4, 4)])
+        self.assertEqual(r.wait(1, 0), 1)
+        self.assertEqual(r.wait(2, 0), 2)
+        self.assertEqual(r.wait(3, 0), 2)
+        self.assertEqual(r.wait(4, 0), 4)
+        self.assertEqual(r.wait(5, 0), 4)
+        self.assertEqual(r.wait(6, 0), 4)
+
+    def test_marked_wait_invalid_attempt(self):
+        self.assertRaises(IndexError, Retrying, wait_markers=[(0, 1)])
+
+    def test_marked_wait_duplicate_attempt(self):
+        self.assertRaises(IndexError, Retrying, wait_markers=[(2, 1), (2, 2)])
 
 class NoneReturnUntilAfterCount:
     """


### PR DESCRIPTION
Often times retrying is done in a stepping manner whereupon
the first N attempts wait X ms, the next M attempts wait for Y ms,
etc. This patch implements support for such waiting by introducing
the notion of 'wait markers'. Wait markers are simply tuples that
define a set of attempts and their corresponding waits to go into
effect.

A handful of unit tests are also included.
