### PR TITLE
add failure_callback param

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -32,3 +32,4 @@ Patches and Suggestions
 - Jonathan Herriott
 - Job Evers
 - Cyrus Durgin
+- Daniel Bennett

--- a/README.rst
+++ b/README.rst
@@ -141,6 +141,17 @@ We can also use the result of the function to alter the behavior of retrying.
     def might_return_none():
         print "Retry forever ignoring Exceptions with no wait if return value is None"
 
+Don't like RetryError on failure?  Try running a callback instead.
+
+.. code-block:: python
+
+    def return_last_result(attempt):
+        """Return the last result of the function instead of raising an exception"""
+        return attempt.value
+
+    @retry(stop_max_attempt_number=3, retry_on_result=retry_if_result_none, failure_callback=return_last_result)
+    def eventually_return_none():
+        print("Return None after trying not to")
 
 Any combination of stop, wait, etc. is also supported to give you the freedom to mix and match.
 

--- a/retrying.py
+++ b/retrying.py
@@ -77,7 +77,8 @@ class Retrying(object):
                  wait_func=None,
                  wait_jitter_max=None,
                  before_attempts=None,
-                 after_attempts=None):
+                 after_attempts=None,
+                 failure_callback=None):
 
         self._stop_max_attempt_number = 5 if stop_max_attempt_number is None else stop_max_attempt_number
         self._stop_max_delay = 100 if stop_max_delay is None else stop_max_delay
@@ -92,6 +93,7 @@ class Retrying(object):
         self._wait_jitter_max = 0 if wait_jitter_max is None else wait_jitter_max
         self._before_attempts = before_attempts
         self._after_attempts = after_attempts
+        self._failure_callback = failure_callback
 
         # TODO add chaining of stop behaviors
         # stop behavior
@@ -235,6 +237,8 @@ class Retrying(object):
 
             delay_since_first_attempt_ms = int(round(time.time() * 1000)) - start_time
             if self.stop(attempt_number, delay_since_first_attempt_ms):
+                if self._failure_callback:
+                    return self._failure_callback(attempt)
                 if not self._wrap_exception and attempt.has_exception:
                     # get() on an attempt with an exception should cause it to be raised, but raise just in case
                     raise attempt.get()


### PR DESCRIPTION
Addresses issue #61 

Being able to call a custom function when all retries have failed is useful for a few applications.

* Do nothing
* Log and re-raise
* Return the value of the last function call
* Send notification somewhere (email, chat, error tracker, etc)

This approach returns the last `Attempt` which provides access to the last function return value, or exception details depending on the failure conditions.