### PR TITLE
Retry error message

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -32,3 +32,4 @@ Patches and Suggestions
 - Jonathan Herriott
 - Job Evers
 - Cyrus Durgin
+- Luca Castoro

--- a/test_retrying.py
+++ b/test_retrying.py
@@ -468,5 +468,19 @@ class TestBeforeAfterAttempts(unittest.TestCase):
 
         self.assertTrue(TestBeforeAfterAttempts._attempt_number is 2)
 
+class TestMeaningfulMessage(unittest.TestCase):
+
+    def test_function_name(self):
+        @retry(retry_on_result = lambda x: not x, stop_max_attempt_number = 5)
+        def just_a_function():
+            return 0
+        self.assertRaisesRegexp(RetryError, 'just_a_function', just_a_function)
+
+    def test_custom_message(self):
+        @retry(retry_on_result = lambda x: not x, stop_max_attempt_number = 5, custom_message = 'hello world')
+        def just_a_function():
+            return 0
+        self.assertRaisesRegexp(RetryError, 'hello world', just_a_function)
+
 if __name__ == '__main__':
     unittest.main()

--- a/test_retrying.py
+++ b/test_retrying.py
@@ -481,7 +481,7 @@ class TestMeaningfulMessage(unittest.TestCase):
             just_a_function()
             self.assertFalse(True)
         except RetryError as ex:
-            self.assertIn('just_a_function', str(ex))
+            self.assertTrue('just_a_function' in str(ex))
 
     def test_custom_message(self):
 
@@ -493,7 +493,7 @@ class TestMeaningfulMessage(unittest.TestCase):
             just_a_function()
             self.assertFalse(True)
         except RetryError as ex:
-            self.assertIn('hello world', str(ex))
+            self.assertTrue('hello world' in str(ex))
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_retrying.py
+++ b/test_retrying.py
@@ -12,6 +12,7 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 
+import sys
 import time
 import unittest
 
@@ -471,16 +472,28 @@ class TestBeforeAfterAttempts(unittest.TestCase):
 class TestMeaningfulMessage(unittest.TestCase):
 
     def test_function_name(self):
+
         @retry(retry_on_result = lambda x: not x, stop_max_attempt_number = 5)
         def just_a_function():
             return 0
-        self.assertRaisesRegexp(RetryError, 'just_a_function', just_a_function)
+
+        try:
+            just_a_function()
+            self.assertFalse(True)
+        except RetryError as ex:
+            self.assertIn('just_a_function', str(ex))
 
     def test_custom_message(self):
+
         @retry(retry_on_result = lambda x: not x, stop_max_attempt_number = 5, custom_message = 'hello world')
         def just_a_function():
             return 0
-        self.assertRaisesRegexp(RetryError, 'hello world', just_a_function)
+
+        try:
+            just_a_function()
+            self.assertFalse(True)
+        except RetryError as ex:
+            self.assertIn('hello world', str(ex))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I propose a small change to improve the meaningfulness of the string representation of a (failed) Attempt.
Now when serializing the `Attempt` instance (likely when catching a `RetryError` exception) the returned string contains a customizable message or, when not specified, the name of the function that was wrapped by `@retry`.
I updated the unit tests as well to verify the correct behavior of the feature and of course checked that other functionalities were not affected.

P.s. I know I should have opened an issue first, but I thought it would be faster to just make a PR.