### PR TITLE
Generator support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 *.pyc
 *.egg-info
 build
+venv

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - 3.3
   - 3.4
   - 3.5
+  - 3.6
   - pypy
 
 script: python setup.py test

--- a/retrying.py
+++ b/retrying.py
@@ -295,8 +295,8 @@ class Retrying(object):
                 attempt = Attempt(tb, attempt_number, True)
 
             if not self.should_reject(attempt):
-                return self._yelded_data(attempt)
-
+                self._yelded_data(attempt)
+                return
             if self._after_attempts:
                 self._after_attempts(attempt_number)
 

--- a/retrying.py
+++ b/retrying.py
@@ -20,7 +20,7 @@ import traceback
 import six
 
 
-if sys.version_info >= (3, 0):
+if sys.version_info >= (3, 5):
     def _is_async(fn):
         return inspect.isasyncgenfunction(fn) or inspect.isgeneratorfunction(fn)
 else:

--- a/retrying.py
+++ b/retrying.py
@@ -287,8 +287,9 @@ class Retrying(object):
                 self._before_attempts(attempt_number)
 
             try:
-                result = yield from self._deterministic_generation(fn, *args, **kwargs)
-                attempt = Attempt(result, attempt_number, False)
+                for d in self._deterministic_generation(fn, *args, **kwargs):
+                    yield d
+                attempt = Attempt(None, attempt_number, False)
             except:
                 tb = sys.exc_info()
                 attempt = Attempt(tb, attempt_number, True)

--- a/retrying.py
+++ b/retrying.py
@@ -317,7 +317,8 @@ class Retrying(object):
             attempt_number += 1
 
     def _yelded_data(self, attempt):
-        yield from attempt.get(self._wrap_exception)
+        for d in attempt.get(self._wrap_exception):
+            yield d
 
     def _deterministic_generation(self, fn, *args, **kwargs):
         for i, v in enumerate(fn(*args, **kwargs)):

--- a/retrying.py
+++ b/retrying.py
@@ -20,7 +20,7 @@ import traceback
 import six
 
 
-if sys.version_info >= (3, 5):
+if sys.version_info >= (3, 6):
     def _is_async(fn):
         return inspect.isasyncgenfunction(fn) or inspect.isgeneratorfunction(fn)
 else:

--- a/test_retrying.py
+++ b/test_retrying.py
@@ -473,7 +473,7 @@ class TestBeforeAfterAttempts(unittest.TestCase):
 class TestGenerators(unittest.TestCase):
     def test(self):
         @retry(stop_max_delay=3000)
-        def _f(started: datetime.datetime):
+        def _f(started):
             for i in range(10):
                 if i == 5 and datetime.datetime.now() - started < datetime.timedelta(seconds=2):
                     raise ValueError
@@ -483,7 +483,7 @@ class TestGenerators(unittest.TestCase):
     
     def test_deterministic(self):
         @retry(stop_max_delay=3000, deterministic_generators=True)
-        def _f(started: datetime.datetime):
+        def _f(started):
             for i in range(10):
                 if i == 5 and datetime.datetime.now() - started < datetime.timedelta(seconds=2):
                     raise ValueError
@@ -493,7 +493,7 @@ class TestGenerators(unittest.TestCase):
     def test_deterministic_big_values(self):
         # Do NOT use nondeterministic generators. You would get OOM.
         @retry(stop_max_delay=3000, deterministic_generators=True)
-        def _f(started: datetime.datetime):
+        def _f(started):
             for i in range(sys.maxsize):
                 if i == 5 and datetime.datetime.now() - started < datetime.timedelta(seconds=2):
                     raise ValueError
@@ -508,7 +508,7 @@ class TestGenerators(unittest.TestCase):
 
     def test_simple(self):
         @retry(stop_max_delay=3000)
-        def _f(started: datetime.datetime):
+        def _f(started):
             if datetime.datetime.now() - started < datetime.timedelta(seconds=2):
                 raise ValueError
             yield 'OK'

--- a/test_retrying.py
+++ b/test_retrying.py
@@ -491,10 +491,16 @@ class TestGenerators(unittest.TestCase):
         self.assertEqual(list(range(10)), list(_f(datetime.datetime.now())))
 
     def test_deterministic_big_values(self):
+        if sys.version >= (3, 0):
+            safe_range = range
+        else:
+            # noinspection PyUnresolvedReferences
+            safe_range = xrange
+
         # Do NOT use nondeterministic generators. You would get OOM.
         @retry(stop_max_delay=3000, deterministic_generators=True)
         def _f(started):
-            for i in range(sys.maxsize):
+            for i in safe_range(sys.maxsize):
                 if i == 5 and datetime.datetime.now() - started < datetime.timedelta(seconds=2):
                     raise ValueError
                 yield i

--- a/test_retrying.py
+++ b/test_retrying.py
@@ -491,7 +491,7 @@ class TestGenerators(unittest.TestCase):
         self.assertEqual(list(range(10)), list(_f(datetime.datetime.now())))
 
     def test_deterministic_big_values(self):
-        if sys.version >= (3, 0):
+        if sys.version_info >= (3, 0):
             safe_range = range
         else:
             # noinspection PyUnresolvedReferences


### PR DESCRIPTION
The pull request include support for repeatable generator functions, that is, generator functions that can be invoked many times.
I have implemented 2 different strategies:
1. Full fetch of data: this is useful if you cannot preserve a deterministic order of the generated items; works only if the generator does not produce many elements
2. Real generation of data: this works only on deterministic generators, that is, the order of the generated elements are always the same. Works pretty well with very long generations of items

I have also added Python 3.6 to the travis environments.